### PR TITLE
add --meta param to make it work over Web with JOSM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ARG PLANET_FILE=planet.osm.bz2
 
 COPY planet.osm.bz2 .
 
-RUN /srv/osm3s/bin/init_osm3s.sh "$PLANET_FILE" "$DB_DIR" "$EXEC_DIR" \
+RUN /srv/osm3s/bin/init_osm3s.sh "$PLANET_FILE" "$DB_DIR" "$EXEC_DIR" --meta \
   && rm -f "$PLANET_FILE"
 
 COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
Without meta info, this server can work, but outputs invalid OSM XML (at least as JOSM considers it). Also, you have to do queries ending with `out geom` rather than `out meta` that JOSM adds by default.